### PR TITLE
getX() and getY() of com.google.gwt.maps.client.base.Point should return double

### DIFF
--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/base/Point.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/base/Point.java
@@ -49,7 +49,7 @@ public class Point extends JavaScriptObject {
    * get X coordinate
    * @return
    */
-  public final native int getX() /*-{
+  public final native double getX() /*-{
     return this.x;
   }-*/;
   
@@ -57,7 +57,7 @@ public class Point extends JavaScriptObject {
    * get Y coordinate
    * @return
    */
-  public final native int getY() /*-{
+  public final native double getY() /*-{
     return this.y;
   }-*/;
 }


### PR DESCRIPTION
The x and y coordinates of Point can be doubles. For example 
fromLatLngToPoint(LatLng latlng, Point point);
returns Point with x and y set to double values.
