### PR TITLE
Fix for MapHandlerRegistration typo

### DIFF
--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/events/MapHandlerRegistration.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/events/MapHandlerRegistration.java
@@ -142,7 +142,7 @@ public class MapHandlerRegistration {
 	 * @param listener
 	 */
 	private static native void removeHandlerImpl(JavaScriptObject listener) /*-{
-		$wnd.google.maps.MapsEventListener.addListener(listener);
+		$wnd.google.maps.event.removeListener(listener);
 	}-*/;
 
 	/**


### PR DESCRIPTION
Fixed typo in MapHandlerRegistration.  There was an error when removing a click listener from a map handler.
