### PR TITLE
Use setMap / getMap in Layer objects

### DIFF
--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/adsense/AdUnitOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/adsense/AdUnitOptions.java
@@ -52,7 +52,7 @@ public class AdUnitOptions extends JavaScriptObject {
   }
   
   private final native MapImpl getMapImpl() /*-{
-    return this.map;
+    return this.getMap();
   }-*/;
   
   /**
@@ -100,11 +100,15 @@ public class AdUnitOptions extends JavaScriptObject {
    * @param mapWidget
    */
   public final void setMap(MapWidget mapWidget) {
-    setMapImpl(mapWidget.getJso());
+    if (mapWidget == null) {
+      setMapImpl(null);
+    } else {
+      setMapImpl(mapWidget.getJso());
+    }
   }
   
   private final native void setMapImpl(MapImpl map) /*-{
-    this.map = map;
+    this.setMap(map);
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/drawinglib/DrawingManagerOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/drawinglib/DrawingManagerOptions.java
@@ -105,11 +105,15 @@ public class DrawingManagerOptions extends JavaScriptObject {
    * @param mapWidget
    */
   public final void setMap(MapWidget mapWidget) {
-    setMapImpl(mapWidget.getJso());
+    if (mapWidget == null) {
+      setMapImpl(null);
+    } else {
+      setMapImpl(mapWidget.getJso());
+    }
   }
   
   private final native void setMapImpl(MapImpl map) /*-{
-    this.map = map;
+    this.setMap(map);
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/layers/FusionTablesLayer.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/layers/FusionTablesLayer.java
@@ -47,7 +47,7 @@ public class FusionTablesLayer extends MVCObject<FusionTablesLayer> {
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.map = map;
+    this.setMap(map);
   }-*/;
   
   /**
@@ -58,7 +58,7 @@ public class FusionTablesLayer extends MVCObject<FusionTablesLayer> {
   }
 
   private final native MapImpl getMapImpl() /*-{
-    return this.map;
+    return this.getMap();
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/layers/FusionTablesLayerOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/layers/FusionTablesLayerOptions.java
@@ -59,11 +59,15 @@ public class FusionTablesLayerOptions extends JavaScriptObject {
    * @param mapWidget
    */
   public final void setMap(MapWidget mapWidget) {
-    setMapImpl(mapWidget.getJso());
+    if (mapWidget == null) {
+      setMapImpl(null);
+    } else {
+      setMapImpl(mapWidget.getJso());
+    }
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.map = map;
+    this.setMap(map);
   }-*/;
   
   /**
@@ -74,7 +78,7 @@ public class FusionTablesLayerOptions extends JavaScriptObject {
   }
 
   private final native MapImpl getMapImpl() /*-{
-    return this.map;
+    return this.getMap();
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/layers/FusionTablesLayerOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/layers/FusionTablesLayerOptions.java
@@ -67,7 +67,7 @@ public class FusionTablesLayerOptions extends JavaScriptObject {
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.setMap(map);
+    this.map = map;
   }-*/;
   
   /**
@@ -78,7 +78,7 @@ public class FusionTablesLayerOptions extends JavaScriptObject {
   }
 
   private final native MapImpl getMapImpl() /*-{
-    return this.getMap();
+    return this.map;
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/layers/KmlLayerOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/layers/KmlLayerOptions.java
@@ -43,11 +43,15 @@ public class KmlLayerOptions extends JavaScriptObject {
    * @param mapWidget
    */
   public final void setMap(MapWidget mapWidget) {
-    setMapImpl(mapWidget.getJso());
+    if (mapWidget == null) {
+      setMapImpl(null);
+    } else {
+      setMapImpl(mapWidget.getJso());
+    }
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.map = map;
+    this.setMap(map);
   }-*/;
   
   /**
@@ -58,7 +62,7 @@ public class KmlLayerOptions extends JavaScriptObject {
   }
 
   private final native MapImpl getMapImpl() /*-{
-    return this.map;
+    return this.getMap();
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/layers/KmlLayerOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/layers/KmlLayerOptions.java
@@ -51,7 +51,7 @@ public class KmlLayerOptions extends JavaScriptObject {
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.setMap(map);
+    this.map = map;
   }-*/;
   
   /**
@@ -62,7 +62,7 @@ public class KmlLayerOptions extends JavaScriptObject {
   }
 
   private final native MapImpl getMapImpl() /*-{
-    return this.getMap();
+    return this.map;
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/Circle.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/Circle.java
@@ -95,7 +95,7 @@ public class Circle extends MVCObject<Circle> {
 	}
 
 	private final native void setMapImpl(MapImpl map) /*-{
-		this.map = map;
+		this.setMap(map);
 	}-*/;
 
 	/**
@@ -106,7 +106,7 @@ public class Circle extends MVCObject<Circle> {
 	}
 
 	private final native MapImpl getMapImpl() /*-{
-		return this.map;
+		return this.getMap();
 	}-*/;
 
 	/**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/CircleOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/CircleOptions.java
@@ -97,7 +97,7 @@ public class CircleOptions extends JavaScriptObject {
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.setMap(map);
+    this.map = map;
   }-*/;
   
   /**
@@ -108,7 +108,7 @@ public class CircleOptions extends JavaScriptObject {
   }
   
   private final native MapImpl getMapImpl() /*-{
-    return this.getMap();
+    return this.map;
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/CircleOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/CircleOptions.java
@@ -89,11 +89,15 @@ public class CircleOptions extends JavaScriptObject {
    * @param mapWidget
    */
   public final void setMap(MapWidget mapWidget) {
-    setMapImpl(mapWidget.getJso());
+    if (mapWidget == null) {
+      setMapImpl(null);
+    } else {
+      setMapImpl(mapWidget.getJso());
+    }
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.map = map;
+    this.setMap(map);
   }-*/;
   
   /**
@@ -104,7 +108,7 @@ public class CircleOptions extends JavaScriptObject {
   }
   
   private final native MapImpl getMapImpl() /*-{
-    return this.map;
+    return this.getMap();
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/GroundOverlayOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/GroundOverlayOptions.java
@@ -43,11 +43,15 @@ public class GroundOverlayOptions extends JavaScriptObject {
    * @param mapWidget
    */
   public final void setMap(MapWidget mapWidget) {
-    setMapImpl(mapWidget.getJso());
+    if (mapWidget == null) {
+      setMapImpl(null);
+    } else {
+      setMapImpl(mapWidget.getJso());
+    }
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.map = map;
+    this.setMap(map);
   }-*/;
   
   /**
@@ -58,7 +62,7 @@ public class GroundOverlayOptions extends JavaScriptObject {
   }
   
   private final native MapImpl getMapImpl() /*-{
-    return this.map;
+    return this.getMap();
   }-*/;
   
 }

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/GroundOverlayOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/GroundOverlayOptions.java
@@ -51,7 +51,7 @@ public class GroundOverlayOptions extends JavaScriptObject {
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.setMap(map);
+    this.map = map;
   }-*/;
   
   /**
@@ -62,7 +62,7 @@ public class GroundOverlayOptions extends JavaScriptObject {
   }
   
   private final native MapImpl getMapImpl() /*-{
-    return this.getMap();
+    return this.map;
   }-*/;
   
 }

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/MarkerOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/MarkerOptions.java
@@ -137,11 +137,15 @@ public class MarkerOptions extends JavaScriptObject {
    * @param mapWidget
    */
   public final void setMap(MapWidget mapWidget) {
-    setMapImpl(mapWidget.getJso());
+    if (mapWidget == null) {
+      setMapImpl(null);
+    } else {
+      setMapImpl(mapWidget.getJso());
+    }
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.map = map;
+    this.setMap(map);
   }-*/;
   
   /**
@@ -152,7 +156,7 @@ public class MarkerOptions extends JavaScriptObject {
   }
   
   private final native MapImpl getMapImpl() /*-{
-    return this.map;
+    return this.getMap();
   }-*/;
   
   public final void setMap(StreetViewPanoramaWidget streetViewPanoramaWidget) {
@@ -160,7 +164,7 @@ public class MarkerOptions extends JavaScriptObject {
   }
 
   private final native void setMapImpl(StreetViewPanoramaImpl map) /*-{
-    this.map = map;
+    this.setMap(map);
   }-*/;
   
   /**
@@ -171,7 +175,7 @@ public class MarkerOptions extends JavaScriptObject {
   }
   
   private final native StreetViewPanoramaImpl getMapImpl_Street() /*-{
-    return this.map;
+    return this.getMap();
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/MarkerOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/MarkerOptions.java
@@ -138,14 +138,14 @@ public class MarkerOptions extends JavaScriptObject {
    */
   public final void setMap(MapWidget mapWidget) {
     if (mapWidget == null) {
-      setMapImpl(null);
+      setMapImpl((MapImpl)null);
     } else {
       setMapImpl(mapWidget.getJso());
     }
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.setMap(map);
+    this.map = map;
   }-*/;
   
   /**
@@ -156,7 +156,7 @@ public class MarkerOptions extends JavaScriptObject {
   }
   
   private final native MapImpl getMapImpl() /*-{
-    return this.getMap();
+    return this.map;
   }-*/;
   
   public final void setMap(StreetViewPanoramaWidget streetViewPanoramaWidget) {
@@ -164,7 +164,7 @@ public class MarkerOptions extends JavaScriptObject {
   }
 
   private final native void setMapImpl(StreetViewPanoramaImpl map) /*-{
-    this.setMap(map);
+    this.map = map;
   }-*/;
   
   /**
@@ -175,7 +175,7 @@ public class MarkerOptions extends JavaScriptObject {
   }
   
   private final native StreetViewPanoramaImpl getMapImpl_Street() /*-{
-    return this.getMap();
+    return this.map;
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/PolygonOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/PolygonOptions.java
@@ -88,7 +88,7 @@ public class PolygonOptions extends JavaScriptObject {
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.setMap(map);
+    this.map = map;
   }-*/;
 
   /**
@@ -99,7 +99,7 @@ public class PolygonOptions extends JavaScriptObject {
   }
 
   private final native MapImpl getMapImpl() /*-{
-   return this.getMap();
+   return this.map;
  }-*/;
 
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/PolygonOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/PolygonOptions.java
@@ -80,11 +80,15 @@ public class PolygonOptions extends JavaScriptObject {
    * @param mapWidget
    */
   public final void setMap(MapWidget mapWidget) {
-    setMapImpl(mapWidget.getJso());
+    if (mapWidget == null) {
+      setMapImpl(null);
+    } else {
+      setMapImpl(mapWidget.getJso());
+    }
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.map = map;
+    this.setMap(map);
   }-*/;
 
   /**
@@ -95,7 +99,7 @@ public class PolygonOptions extends JavaScriptObject {
   }
 
   private final native MapImpl getMapImpl() /*-{
-   return this.map;
+   return this.getMap();
  }-*/;
 
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/PolylineOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/PolylineOptions.java
@@ -69,7 +69,7 @@ public class PolylineOptions extends JavaScriptObject {
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.setMap(map);
+    this.map = map;
   }-*/;
   
   /**
@@ -80,7 +80,7 @@ public class PolylineOptions extends JavaScriptObject {
   }
 
   private final native MapImpl getMapImpl() /*-{
-    return this.getMap();
+    return this.map;
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/PolylineOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/PolylineOptions.java
@@ -61,11 +61,15 @@ public class PolylineOptions extends JavaScriptObject {
    * @param mapWidget
    */
   public final void setMap(MapWidget mapWidget) {
-    setMapImpl(mapWidget.getJso());
+    if (mapWidget == null) {
+      setMapImpl(null);
+    } else {
+      setMapImpl(mapWidget.getJso());
+    }
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.map = map;
+    this.setMap(map);
   }-*/;
   
   /**
@@ -76,7 +80,7 @@ public class PolylineOptions extends JavaScriptObject {
   }
 
   private final native MapImpl getMapImpl() /*-{
-    return this.map;
+    return this.getMap();
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/Rectangle.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/Rectangle.java
@@ -86,7 +86,7 @@ public class Rectangle extends MVCObject<Rectangle> {
 	}
 
 	private final native void setMapImpl(MapImpl map) /*-{
-		this.map = map;
+		this.setMap(map);
 	}-*/;
 
 	/**
@@ -97,7 +97,7 @@ public class Rectangle extends MVCObject<Rectangle> {
 	}
 
 	private final native MapImpl getMapImpl() /*-{
-		return this.map;
+		return this.getMap();
 	}-*/;
 
 	/**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/RectangleOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/RectangleOptions.java
@@ -89,11 +89,15 @@ public class RectangleOptions extends JavaScriptObject {
    * @param mapWidget
    */
   public final void setMap(MapWidget mapWidget) {
-    setMapImpl(mapWidget.getJso());
+    if (mapWidget == null) {
+      setMapImpl(null);
+    } else {
+      setMapImpl(mapWidget.getJso());
+    }
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.map = map;
+    this.setMap(map);
   }-*/;
   
   /**
@@ -104,7 +108,7 @@ public class RectangleOptions extends JavaScriptObject {
   }
   
   private final native MapImpl getMapImpl() /*-{
-    return this.map;
+    return this.getMap();
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/RectangleOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/overlays/RectangleOptions.java
@@ -97,7 +97,7 @@ public class RectangleOptions extends JavaScriptObject {
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.setMap(map);
+    this.map = map;
   }-*/;
   
   /**
@@ -108,7 +108,7 @@ public class RectangleOptions extends JavaScriptObject {
   }
   
   private final native MapImpl getMapImpl() /*-{
-    return this.getMap();
+    return this.map;
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/panoramiolib/PanoramioLayerOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/panoramiolib/PanoramioLayerOptions.java
@@ -38,7 +38,7 @@ public class PanoramioLayerOptions extends JavaScriptObject {
   }
   
   private final native MapImpl getMapImpl() /*-{
-    return this.map;
+    return this.getMap();
   }-*/;
 
   /**
@@ -75,11 +75,15 @@ public class PanoramioLayerOptions extends JavaScriptObject {
    * @param mapWidget
    */
   public final void setMap(MapWidget mapWidget) {
-    setMapImpl(mapWidget.getJso());
+    if (mapWidget == null) {
+      setMapImpl(null);
+    } else {
+      setMapImpl(mapWidget.getJso());
+    }
   }
   
   private final native void setMapImpl(MapImpl map) /*-{
-    this.map = map;
+    this.setMap(map);
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/panoramiolib/PanoramioLayerOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/panoramiolib/PanoramioLayerOptions.java
@@ -38,7 +38,7 @@ public class PanoramioLayerOptions extends JavaScriptObject {
   }
   
   private final native MapImpl getMapImpl() /*-{
-    return this.getMap();
+    return this.map;
   }-*/;
 
   /**
@@ -83,7 +83,7 @@ public class PanoramioLayerOptions extends JavaScriptObject {
   }
   
   private final native void setMapImpl(MapImpl map) /*-{
-    this.setMap(map);
+    this.map = map;
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/services/DirectionsRendererOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/services/DirectionsRendererOptions.java
@@ -92,11 +92,15 @@ public class DirectionsRendererOptions extends JavaScriptObject {
    * @param mapWidget
    */
   public final void setMap(MapWidget mapWidget) {
-    setMapImpl(mapWidget.getJso());
+    if (mapWidget == null) {
+      setMapImpl(null);
+    } else {
+      setMapImpl(mapWidget.getJso());
+    }
   }
 
   private final native void setMapImpl(MapImpl map) /*-{
-    this.map = map;
+    this.setMap(map);
   }-*/;
   
   /**
@@ -107,7 +111,7 @@ public class DirectionsRendererOptions extends JavaScriptObject {
   }
   
   private final native MapImpl getMapImpl() /*-{
-    return this.map;
+    return this.getMap();
   }-*/;
   
   /**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/weatherlib/WeatherLayerOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/weatherlib/WeatherLayerOptions.java
@@ -105,7 +105,7 @@ public class WeatherLayerOptions extends JavaScriptObject {
 	}
 
 	private final native void setMapImpl(MapImpl map) /*-{
-		this.setMap(map);
+		this.map = map;
 	}-*/;
 
 	/**
@@ -116,7 +116,7 @@ public class WeatherLayerOptions extends JavaScriptObject {
 	}
 
 	private final native MapImpl getMapImpl() /*-{
-		return this.getMap();
+		return this.map;
 	}-*/;
 
 	/**

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/weatherlib/WeatherLayerOptions.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/weatherlib/WeatherLayerOptions.java
@@ -105,7 +105,7 @@ public class WeatherLayerOptions extends JavaScriptObject {
 	}
 
 	private final native void setMapImpl(MapImpl map) /*-{
-		this.map = map;
+		this.setMap(map);
 	}-*/;
 
 	/**
@@ -116,7 +116,7 @@ public class WeatherLayerOptions extends JavaScriptObject {
 	}
 
 	private final native MapImpl getMapImpl() /*-{
-		return this.map;
+		return this.getMap();
 	}-*/;
 
 	/**


### PR DESCRIPTION
Hi,

I send a pull request with changes in several Layer objects. It fixes the removal of the layers from the map.

There was a similar commit (https://github.com/branflake2267/GWT-Maps-V3-Api/commit/eccd442740ce657a055ffa1dde92d2f7c8d7bd4a) for PanoramioLayer, this includes all the other layers.

At first I thought Options objects needed the same change but after running the tests I found they didn't.

Thanks for the library, it's very useful! Keep up the good work.

Hope my first pull request is ok! :)

Jorge
