### PR TITLE
Fixed typo in setRadius

### DIFF
--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/placeslib/PlaceSearchRequest.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/placeslib/PlaceSearchRequest.java
@@ -90,15 +90,34 @@ public class PlaceSearchRequest extends JavaScriptObject {
   /**
    * The distance from the given location within which to search for Places, in meters. The maximum allowed value is 50000
    * @param radius
+   * @deprecated
+   * @see #setRadius(double)
    */
-  public final native void setRaidus(double radius) /*-{
+  public final void setRaidus(double radius) {
+    this.setRadius(radius);
+  }
+  
+  /**
+   * The distance from the given location within which to search for Places, in meters. The maximum allowed value is 50000
+   * @param radius
+   */
+  public final native void setRadius(double radius) /*-{
     this.radius = radius;
   }-*/;
   
   /**
    * The distance from the given location within which to search for Places, in meters. The maximum allowed value is 50000
+   * @deprecated
+   * @see #getRadius()
    */
-  public final native double getRaidus() /*-{
+  public final double getRaidus() {
+    return this.getRadius();
+  }
+  
+  /**
+   * The distance from the given location within which to search for Places, in meters. The maximum allowed value is 50000
+   */
+  public final native double getRadius() /*-{
     return this.radius;
   }-*/;
   

--- a/Apis_Google_Maps/src/com/google/gwt/maps/client/placeslib/PlaceSearchRequest.java
+++ b/Apis_Google_Maps/src/com/google/gwt/maps/client/placeslib/PlaceSearchRequest.java
@@ -1,5 +1,6 @@
 package com.google.gwt.maps.client.placeslib;
 
+import java.lang.Deprecated;
 import java.util.List;
 
 import com.google.gwt.ajaxloader.client.ArrayHelper;
@@ -93,6 +94,7 @@ public class PlaceSearchRequest extends JavaScriptObject {
    * @deprecated
    * @see #setRadius(double)
    */
+  @Deprecated
   public final void setRaidus(double radius) {
     this.setRadius(radius);
   }
@@ -110,6 +112,7 @@ public class PlaceSearchRequest extends JavaScriptObject {
    * @deprecated
    * @see #getRadius()
    */
+  @Deprecated
   public final double getRaidus() {
     return this.getRadius();
   }

--- a/Apis_Google_Maps/test/com/google/gwt/maps/client/placelib/PlaceResultTest.java
+++ b/Apis_Google_Maps/test/com/google/gwt/maps/client/placelib/PlaceResultTest.java
@@ -109,7 +109,7 @@ public class PlaceResultTest extends GWTTestCase {
       public void run() {
         PlaceSearchRequest o = PlaceSearchRequest.newInstance();
         double left = 10.02;
-        o.setRaidus(left);
+        o.setRadius(left);
         double right = o.getRaidus();
         assertEquals(left, right);
         finishTest();


### PR DESCRIPTION
Fixed typo: setRaidus -> setRadius, getRaidus -> setRadius.

Old method still in place but deprecated.
