### PR TITLE
Remove gwt dev dependency and add exclusions.

### DIFF
--- a/gwt-maps-showcase/pom.xml
+++ b/gwt-maps-showcase/pom.xml
@@ -180,6 +180,12 @@
 		<dependency>
 			<groupId>com.google.gwt.google-apis</groupId>
 			<artifactId>gwt-ajaxloader</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.gwt</groupId>
+					<artifactId>gwt-dev</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- Just the necessary GWT bits -->

--- a/gwt-maps-showcase/pom.xml
+++ b/gwt-maps-showcase/pom.xml
@@ -114,7 +114,7 @@
 
 		<pluginManagement>
 			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings 
+				<!--This plugin's configuration is used to store Eclipse m2e settings
 					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
@@ -175,23 +175,19 @@
             <version>3.9.0</version>
             <scope>provided</scope>
         </dependency>
-                
+
 		<!-- GWT Google Apis Core -->
 		<dependency>
 			<groupId>com.google.gwt.google-apis</groupId>
 			<artifactId>gwt-ajaxloader</artifactId>
 		</dependency>
-        
+
 		<!-- Just the necessary GWT bits -->
 		<dependency>
 			<groupId>com.google.gwt</groupId>
 			<artifactId>gwt-user</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.google.gwt</groupId>
-			<artifactId>gwt-dev</artifactId>
-		</dependency>
-        
+
         <!-- Google App Engine dependencies -->
         <dependency>
             <groupId>com.google.appengine</groupId>
@@ -215,7 +211,7 @@
             <version>${gae.version}</version>
             <scope>test</scope>
         </dependency>
-        
+
 		<!-- Testing -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,12 @@
 				<artifactId>gwt-ajaxloader</artifactId>
 				<version>1.1.0</version>
 				<scope>compile</scope>
+				<exclusions>
+					<exclusion>
+						<groupId>com.google.gwt</groupId>
+						<artifactId>gwt-dev</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
             
 			<!-- Just the necessary GWT bits -->

--- a/pom.xml
+++ b/pom.xml
@@ -216,12 +216,6 @@
 				<version>${gwt.version}</version>
 				<scope>provided</scope> <!-- don't copy to jar -->
 			</dependency>
-			<dependency>
-				<groupId>com.google.gwt</groupId>
-				<artifactId>gwt-dev</artifactId>
-				<version>${gwt.version}</version>
-				<scope>provided</scope> <!-- don't copy to jar -->
-			</dependency>
             
 			<!-- Testing -->
 			<dependency>


### PR DESCRIPTION
As noted in #88 and #89, conflicting gwt-dev versions can cause an error, but the dependency can be removed.
