### PR TITLE
Brandon deploy

### DIFF
--- a/gwt-maps-api/pom.xml
+++ b/gwt-maps-api/pom.xml
@@ -1,30 +1,42 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-    
-	<parent>
-		<groupId>com.github.branflake2267</groupId>
-		<artifactId>gwt-maps</artifactId>
-		<version>3.9.0</version>
-	</parent>
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.branflake2267</groupId>
+        <artifactId>gwt-maps</artifactId>
+        <version>3.9.0</version>
+    </parent>
 
     <artifactId>gwt-maps-api</artifactId>
     <name>GWT Maps API V3 - Core API</name>
 
-	<build>
+    <build>
         <resources>
-          <resource>
-            <directory>src/main/java</directory>
-            <includes>
-              <include>**/*.java</include>
-              <include>**/*.gwt.xml</include>
-            </includes>
-          </resource>
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.java</include>
+                    <include>**/*.gwt.xml</include>
+                </includes>
+            </resource>
         </resources>
-    
-		<plugins>
-		
+
+        <plugins>
+            <!-- JUnit Testing -->
+            <!-- run 'mvn test' for running JUnit Tests -->
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*GwtTest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
             <!-- GWT -->
+            <!-- run 'mvn integration-test' for running the GwtTestSuite -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
@@ -35,10 +47,10 @@
                     <excludes>**/*GwtTest.java</excludes>
                     <mode>htmlunit</mode>
                     <testTimeOut>180</testTimeOut>
-                    
+
                     <strict>true</strict>
                     <style>${gwt.style}</style>
-                    
+
                     <compileSourcesArtifacts>
                         <compileSourcesArtifact>com.google.gwt.maps:Maps</compileSourcesArtifact>
                     </compileSourcesArtifacts>
@@ -57,88 +69,85 @@
                         <artifactId>gwt-user</artifactId>
                         <version>${gwt.version}</version>
                     </dependency>
-                    <!-- <dependency>
-                        <groupId>com.google.gwt</groupId>
-                        <artifactId>gwt-dev</artifactId>
-                        <version>${gwt.version}</version>
-                    </dependency> -->
+                    <!-- <dependency> <groupId>com.google.gwt</groupId> <artifactId>gwt-dev</artifactId> 
+                        <version>${gwt.version}</version> </dependency> -->
                     <dependency>
                         <groupId>com.google.gwt</groupId>
                         <artifactId>gwt-servlet</artifactId>
                         <version>${gwt.version}</version>
                     </dependency>
-              </dependencies>
+                </dependencies>
             </plugin>
- 
-			<!-- JUnit Testing -->
-			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.6</version>
-				<configuration>
-					<additionalClasspathElements>
-						<additionalClasspathElement>${project.build.sourceDirectory}</additionalClasspathElement>
-						<additionalClasspathElement>${project.build.testSourceDirectory}</additionalClasspathElement>
-					</additionalClasspathElements>
-					<useManifestOnlyJar>false</useManifestOnlyJar>
-					<forkMode>always</forkMode>
 
-					<!-- Multi-thread -->
-					<parallel>classes</parallel>
-					<threadCount>4</threadCount>
-					<perCoreThreadCount>true</perCoreThreadCount>
-					<!-- Only run the GWTTests -->
-					<includes>
-						<include>**/*Suite.java</include>
-					</includes>
-					<excludes>
-						<exclude>**/*GwtTest.java</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
+            <!-- JUnit Testing -->
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <additionalClasspathElements>
+                        <additionalClasspathElement>${project.build.sourceDirectory}</additionalClasspathElement>
+                        <additionalClasspathElement>${project.build.testSourceDirectory}</additionalClasspathElement>
+                    </additionalClasspathElements>
+                    <useManifestOnlyJar>false</useManifestOnlyJar>
+                    <forkMode>always</forkMode>
 
-			<!-- Deploy source code in the repository -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>2.1.2</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			
-			<!-- Deploy javadoc in the repository -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.8.1</version>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<encoding>${project.build.sourceEncoding}</encoding>
-					<locale>en</locale>
-					<linksource>true</linksource>
-					<validateLinks>true</validateLinks>
-					<links>
-						<link>http://google-web-toolkit.googlecode.com/svn/javadoc/2.4</link>
-					</links>
-					<quiet>true</quiet>
-					<serialwarn>true</serialwarn>
-					<skip>{$javadocs.skip}</skip>
-					<stylesheet>maven</stylesheet>
-					
-					<!-- GA Tracking code -->
-					<header>
+                    <!-- Multi-thread -->
+                    <parallel>classes</parallel>
+                    <threadCount>4</threadCount>
+                    <perCoreThreadCount>true</perCoreThreadCount>
+                    <!-- Only run the GWTTests -->
+                    <includes>
+                        <include>**/*Suite.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>**/*GwtTest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+            <!-- Deploy source code in the repository -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.1.2</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Deploy javadoc in the repository -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.8.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <locale>en</locale>
+                    <linksource>true</linksource>
+                    <validateLinks>true</validateLinks>
+                    <links>
+                        <link>http://google-web-toolkit.googlecode.com/svn/javadoc/2.4</link>
+                    </links>
+                    <quiet>true</quiet>
+                    <serialwarn>true</serialwarn>
+                    <skip>{$javadocs.skip}</skip>
+                    <stylesheet>maven</stylesheet>
+
+                    <!-- GA Tracking code -->
+                    <header>
 					<![CDATA[
 						<script type="text/javascript">
 						  var _gaq = _gaq || [];
@@ -165,71 +174,71 @@
 								height="30px"></iframe>
 						</div>
 					]]>
-					</header>
-				</configuration>
-			</plugin>
-		</plugins>
+                    </header>
+                </configuration>
+            </plugin>
+        </plugins>
 
-		<pluginManagement>
-			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings 
-					only. It has no influence on the Maven build itself. -->
-				<plugin>
-					<groupId>org.eclipse.m2e</groupId>
-					<artifactId>lifecycle-mapping</artifactId>
-					<version>1.0.0</version>
-					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>
-											org.codehaus.mojo
-										</groupId>
-										<artifactId>
-											gwt-maven-plugin
-										</artifactId>
-										<versionRange>
-											[2.4.0,)
-										</versionRange>
-										<goals>
-											<goal>resources</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-        
-	</build>
+        <pluginManagement>
+            <plugins>
+                <!--This plugin's configuration is used to store Eclipse 
+                    m2e settings only. It has no influence on the Maven build itself. -->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>
+                                            org.codehaus.mojo
+                                        </groupId>
+                                        <artifactId>
+                                            gwt-maven-plugin
+                                        </artifactId>
+                                        <versionRange>
+                                            [2.4.0,)
+                                        </versionRange>
+                                        <goals>
+                                            <goal>resources</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
 
-	<!-- External project dependencies -->
-	<dependencies>
+    </build>
 
-		<!-- GWT Apis -->
-		<dependency>
-			<groupId>com.google.gwt.google-apis</groupId>
-			<artifactId>gwt-ajaxloader</artifactId>
-		</dependency>
-        
-		<!-- GWT -->
-		<dependency>
-			<groupId>com.google.gwt</groupId>
-			<artifactId>gwt-user</artifactId>
-		</dependency>
-        
-		<!-- Testing -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
+    <!-- External project dependencies -->
+    <dependencies>
 
-	</dependencies>
+        <!-- GWT Apis -->
+        <dependency>
+            <groupId>com.google.gwt.google-apis</groupId>
+            <artifactId>gwt-ajaxloader</artifactId>
+        </dependency>
+
+        <!-- GWT -->
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-user</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+
+    </dependencies>
 
 </project>

--- a/gwt-maps-api/pom.xml
+++ b/gwt-maps-api/pom.xml
@@ -79,32 +79,6 @@
                 </dependencies>
             </plugin>
 
-            <!-- JUnit Testing -->
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.6</version>
-                <configuration>
-                    <additionalClasspathElements>
-                        <additionalClasspathElement>${project.build.sourceDirectory}</additionalClasspathElement>
-                        <additionalClasspathElement>${project.build.testSourceDirectory}</additionalClasspathElement>
-                    </additionalClasspathElements>
-                    <useManifestOnlyJar>false</useManifestOnlyJar>
-                    <forkMode>always</forkMode>
-
-                    <!-- Multi-thread -->
-                    <parallel>classes</parallel>
-                    <threadCount>4</threadCount>
-                    <perCoreThreadCount>true</perCoreThreadCount>
-                    <!-- Only run the GWTTests -->
-                    <includes>
-                        <include>**/*Suite.java</include>
-                    </includes>
-                    <excludes>
-                        <exclude>**/*GwtTest.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-
             <!-- Deploy source code in the repository -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/gwt-maps-api/src/test/java/com/google/gwt/maps/client/overlays/OverlayViewGwtTest.java
+++ b/gwt-maps-api/src/test/java/com/google/gwt/maps/client/overlays/OverlayViewGwtTest.java
@@ -53,7 +53,13 @@ public class OverlayViewGwtTest extends AbstractMapsGWTTestHelper {
     asyncLibTest(new Runnable() {
       @Override
       public void run() {
+        MapOptions options = MapOptions.newInstance();
+        MapWidget mapWidget = new MapWidget(options);
+        mapWidget.setSize("500px", "500px");
+        RootPanel.get().add(mapWidget);
+
         OverlayView o = OverlayView.newInstance();
+        o.setMap(mapWidget);
 
         // TODO - is prototype - not easily tested
         o.draw();

--- a/gwt-maps-showcase/pom.xml
+++ b/gwt-maps-showcase/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.github.branflake2267</groupId>
@@ -8,21 +8,21 @@
         <version>3.9.0</version>
     </parent>
 
-	<artifactId>gwt-maps-showcase</artifactId>
-	<name>GWT Maps API V3 - Showcase</name>
+    <artifactId>gwt-maps-showcase</artifactId>
+    <name>GWT Maps API V3 - Showcase</name>
     <packaging>war</packaging>
 
     <properties>
-     <webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
+        <webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
         <gae.home>
             ${settings.localRepository}/com/google/appengine/appengine-java-sdk/${gae.version}/appengine-java-sdk-${gae.version}
         </gae.home>
     </properties>
 
-	<build>
+    <build>
         <outputDirectory>${webappDirectory}/WEB-INF/classes</outputDirectory>
-        
-		<plugins>
+
+        <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -62,32 +62,33 @@
             <!-- 'mvn gwt:debug' - runs debug mode -->
             <!-- 'mvn gwt:compile' - compiles gwt -->
             <!-- 'mvn integration-test' - runs the gwt tests (*GwtTest.java) -->
-            <!-- 'mvn clean gwt:compile deploy -DskipTests' - deploys to gae & sona with out running tests -->
+            <!-- 'mvn clean gwt:compile deploy -DskipTests' - deploys to 
+                gae & sona with out running tests -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
                 <version>${gwt.version}</version>
                 <configuration>
                     <strict>true</strict>
-                    
+
                     <testTimeOut>180</testTimeOut>
                     <includes>**/*GwtTest.java</includes> <!-- ,**/*GwtTestSuite.java -->
                     <mode>htmlunit</mode>
-                    
+
                     <extraJvmArgs>-Xss1024k -Xmx512M</extraJvmArgs>
                     <logLevel>INFO</logLevel>
                     <style>${gwt.style}</style>
-                    
+
                     <copyWebapp>true</copyWebapp>
                     <hostedWebapp>${webappDirectory}</hostedWebapp>
 
                     <server>com.google.appengine.tools.development.gwt.AppEngineLauncher</server>
                     <appEngineVersion>${gae.version}</appEngineVersion>
                     <appEngineHome>${gae.home}</appEngineHome>
-                    
+
                     <runTarget>showcase.html</runTarget>
                     <module>com.google.gwt.maps.testing.Showcase</module>
-                    
+
                     <!-- <compileReport>${gwt.compileReport}</compileReport> -->
                 </configuration>
                 <dependencies>
@@ -96,11 +97,8 @@
                         <artifactId>gwt-user</artifactId>
                         <version>${gwt.version}</version>
                     </dependency>
-                    <!-- <dependency>
-                        <groupId>com.google.gwt</groupId>
-                        <artifactId>gwt-dev</artifactId>
-                        <version>${gwt.version}</version>
-                    </dependency> -->
+                    <!-- <dependency> <groupId>com.google.gwt</groupId> <artifactId>gwt-dev</artifactId> 
+                        <version>${gwt.version}</version> </dependency> -->
                     <dependency>
                         <groupId>com.google.gwt</groupId>
                         <artifactId>gwt-codeserver</artifactId>
@@ -126,62 +124,62 @@
                     </execution>
                 </executions>
             </plugin>
-		</plugins>
+        </plugins>
 
-		<pluginManagement>
-			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings
-					only. It has no influence on the Maven build itself. -->
-				<plugin>
-					<groupId>org.eclipse.m2e</groupId>
-					<artifactId>lifecycle-mapping</artifactId>
-					<version>1.0.0</version>
-					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>
-											org.codehaus.mojo
-										</groupId>
-										<artifactId>
-											gwt-maven-plugin
-										</artifactId>
-										<versionRange>
-											[2.4.0,)
-										</versionRange>
-										<goals>
-											<goal>resources</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
-					</configuration>
-				</plugin>
+        <pluginManagement>
+            <plugins>
+                <!--This plugin's configuration is used to store Eclipse 
+                    m2e settings only. It has no influence on the Maven build itself. -->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>
+                                            org.codehaus.mojo
+                                        </groupId>
+                                        <artifactId>
+                                            gwt-maven-plugin
+                                        </artifactId>
+                                        <versionRange>
+                                            [2.4.0,)
+                                        </versionRange>
+                                        <goals>
+                                            <goal>resources</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
 
-				<!-- Used for local tomcat debugging -->
-				<plugin>
-					<groupId>org.codehaus.mojo</groupId>
-					<artifactId>tomcat-maven-plugin</artifactId>
-					<version>1.1</version>
-					<configuration>
-						<port>3030</port>
-						<warFile>${project.build.directory}/${project.build.finalName}.war</warFile>
-					</configuration>
-					<goals>
-						<goal>run-war</goal>
-					</goals>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
+                <!-- Used for local tomcat debugging -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>tomcat-maven-plugin</artifactId>
+                    <version>1.1</version>
+                    <configuration>
+                        <port>3030</port>
+                        <warFile>${project.build.directory}/${project.build.finalName}.war</warFile>
+                    </configuration>
+                    <goals>
+                        <goal>run-war</goal>
+                    </goals>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
-	<!-- External project dependencies -->
-	<dependencies>
+    <!-- External project dependencies -->
+    <dependencies>
         <!-- Include Core gwt-maps-api -->
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -190,21 +188,21 @@
             <scope>provided</scope>
         </dependency>
 
-		<!-- GWT Apis - Used for loading the Google maps javascript api -->
-		<dependency>
-			<groupId>com.google.gwt.google-apis</groupId>
-			<artifactId>gwt-ajaxloader</artifactId>
-		</dependency>
+        <!-- GWT Apis - Used for loading the Google maps javascript api -->
+        <dependency>
+            <groupId>com.google.gwt.google-apis</groupId>
+            <artifactId>gwt-ajaxloader</artifactId>
+        </dependency>
 
-		<!-- GWT -->
-		<dependency>
-			<groupId>com.google.gwt</groupId>
-			<artifactId>gwt-user</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.google.gwt</groupId>
-			<artifactId>gwt-dev</artifactId>
-		</dependency>
+        <!-- GWT -->
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-user</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-dev</artifactId>
+        </dependency>
 
         <!-- Google App Engine dependencies -->
         <dependency>
@@ -230,12 +228,12 @@
             <scope>test</scope>
         </dependency>
 
-		<!-- Testing -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
+        <!-- Testing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
 
-	</dependencies>
+    </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,106 +1,108 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<!-- Artifact details that people will use search for this project -->
-	<groupId>com.github.branflake2267</groupId>
-	<artifactId>gwt-maps</artifactId>
-	<version>3.9.0</version>
+    <!-- Artifact details that people will use search for this project -->
+    <groupId>com.github.branflake2267</groupId>
+    <artifactId>gwt-maps</artifactId>
+    <version>3.9.0</version>
     <!-- b/c is a parent POM, others are jars/wars -->
-	<packaging>pom</packaging> 
+    <packaging>pom</packaging>
 
-	<modules>
-		<module>gwt-maps-api</module>
-		<module>gwt-maps-showcase</module>
-	</modules>
+    <modules>
+        <module>gwt-maps-api</module>
+        <module>gwt-maps-showcase</module>
+    </modules>
 
-	<name>GWT Maps API V3</name>
-	<description>GWT library to access Google Maps javascript API</description>
-	<url>https://github.com/branflake2267/GWT-Maps-V3-Api/</url>
-	<inceptionYear>2011</inceptionYear>
-	<organization>
-		<name>GWT Maps API V3</name>
-	</organization>
+    <name>GWT Maps API V3</name>
+    <description>GWT library to access Google Maps javascript API</description>
+    <url>https://github.com/branflake2267/GWT-Maps-V3-Api/</url>
+    <inceptionYear>2011</inceptionYear>
+    <organization>
+        <name>GWT Maps API V3</name>
+    </organization>
 
-	<licenses>
-		<license>
-			<name>Apache License 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
-		</license>
-	</licenses>
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
 
-	<issueManagement>
-		<system>github</system>
-		<url>https://github.com/branflake2267/GWT-Maps-V3-Api</url>
-	</issueManagement>
+    <issueManagement>
+        <system>github</system>
+        <url>https://github.com/branflake2267/GWT-Maps-V3-Api</url>
+    </issueManagement>
 
-	<scm>
-		<connection>scm:git:ssh://github.com/branflake2267/GWT-Maps-V3-Api.git</connection>
-		<developerConnection>scm:git:ssh://github.com/branflake2267/GWT-Maps-V3-Api.git</developerConnection>
-		<url>https://github.com/branflake2267/GWT-Maps-V3-Api</url>
-	</scm>
+    <scm>
+        <connection>scm:git:ssh://github.com/branflake2267/GWT-Maps-V3-Api.git</connection>
+        <developerConnection>scm:git:ssh://github.com/branflake2267/GWT-Maps-V3-Api.git</developerConnection>
+        <url>https://github.com/branflake2267/GWT-Maps-V3-Api</url>
+    </scm>
 
-	<developers>
-		<developer>
-			<id>branflake2267</id>
-			<name>Brandon Donnelson</name>
-			<email>branflake2267@gmail.com</email>
-			<organization>Gone Vertical LLC</organization>
-			<organizationUrl>http://gonevertical.com</organizationUrl>
-			<roles>
-				<role>Lead developer</role>
-			</roles>
-			<timezone>-8</timezone>
-		</developer>
-		<developer>
-			<id>twistedpair</id>
-			<name>Joseph Lust</name>
-			<organization>Lauf Labs LLC</organization>
-			<email>lauflabs@gmail.com</email>
-			<organizationUrl>http://www.lustforge.com/</organizationUrl>
-			<roles>
-				<role>Developer</role>
-			</roles>
-			<timezone>-5</timezone>
-		</developer>
-	</developers>
+    <developers>
+        <developer>
+            <id>branflake2267</id>
+            <name>Brandon Donnelson</name>
+            <email>branflake2267@gmail.com</email>
+            <organization>Gone Vertical LLC</organization>
+            <organizationUrl>http://gonevertical.com</organizationUrl>
+            <roles>
+                <role>Lead developer</role>
+            </roles>
+            <timezone>-8</timezone>
+        </developer>
+        <developer>
+            <id>twistedpair</id>
+            <name>Joseph Lust</name>
+            <organization>Lauf Labs LLC</organization>
+            <email>lauflabs@gmail.com</email>
+            <organizationUrl>http://www.lustforge.com/</organizationUrl>
+            <roles>
+                <role>Developer</role>
+            </roles>
+            <timezone>-5</timezone>
+        </developer>
+    </developers>
 
-	<ciManagement>
-		<system>Team City 7.0.3</system>
-        <url>http://teamcity.codebetter.com/viewType.html?tab&#62;buildTypeStatusDiv&amp;buildTypeId=bt833</url>
-	</ciManagement>
+    <!-- Create a account and request access for permissions to modify -->
+    <!-- Purpose Automatic snapshot deployment, Automatic Showcase Deployment -->
+    <ciManagement>
+        <system>Team City 7.1.2</system>
+        <url>http://teamcity.gonevertical.org/viewType.html?buildTypeId=bt5</url>
+    </ciManagement>
 
-	<properties>
-		<!-- Faster build props -->
-		<javadocs.skip>true</javadocs.skip>        
-        
-		<!-- Java props -->
+    <properties>
+        <!-- Faster build props -->
+        <javadocs.skip>true</javadocs.skip>
+
+        <!-- Java props -->
         <java.version>1.6</java.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<!-- GWT props -->
-		<gwt.version>2.5.0</gwt.version>
+        <!-- GWT props -->
+        <gwt.version>2.5.0</gwt.version>
         <gwt.maven.version>2.5.0</gwt.maven.version>
         <gae.version>1.7.2</gae.version>
         <gwt.style>OBF</gwt.style>
-        
+
         <webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
         <gae.home>${settings.localRepository}/com/google/appengine/appengine-java-sdk/${gae.version}/appengine-java-sdk-${gae.version}</gae.home>
-	</properties>
+    </properties>
 
-	<build>
-		<pluginManagement>
-			<plugins>
-				<!-- Build the core app -->
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>2.3.2</version>
-					<configuration>
-						<source>${java.version}</source>
-						<target>${java.version}</target>
-					</configuration>
-				</plugin>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- Build the core app -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>2.3.2</version>
+                    <configuration>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
+                    </configuration>
+                </plugin>
 
                 <!-- Custom license headers for all files -->
                 <plugin>
@@ -116,17 +118,19 @@
                                     <root>src</root>
                                     <root>target/generated-sources</root>
                                     <root>target/processed-sources</root>
-                                    <!-- Included because HTML/CSS/KML files are here -->
+                                    <!-- Included because HTML/CSS/KML files 
+                                        are here -->
                                     <root>war</root>
                                 </roots>
-                                <!-- Don't touch these compiler generated files -->
+                                <!-- Don't touch these compiler generated 
+                                    files -->
                                 <excludes>
                                     <exclude>**/*.cache.html</exclude>
                                     <exclude>**/*.nocache.html</exclude>
                                     <exclude>**/*.properties</exclude>
                                 </excludes>
                             </configuration>
-                            
+
                             <!-- Bound to run at last phase before compile -->
                             <phase>process-resources</phase>
                             <goals>
@@ -135,8 +139,9 @@
                         </execution>
                     </executions>
                 </plugin>
-                
-                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+
+                <!--This plugin's configuration is used to store Eclipse 
+                    m2e settings only. It has no influence on the Maven build itself. -->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
@@ -169,56 +174,57 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
+            </plugins>
+        </pluginManagement>
+    </build>
 
-	<dependencyManagement>
-		<dependencies>
-			<!-- Google -->
-			<dependency>
-				<groupId>com.google.gwt.google-apis</groupId>
-				<artifactId>gwt-ajaxloader</artifactId>
-				<version>1.1.0</version>
-				<scope>compile</scope>
-			</dependency>
-            
-			<!-- GWT -->
-			<dependency>
-				<groupId>com.google.gwt</groupId>
-				<artifactId>gwt-user</artifactId>
-				<version>${gwt.version}</version>
-				<scope>provided</scope> <!-- don't copy to jar -->
-			</dependency>
+    <dependencyManagement>
+        <dependencies>
+            <!-- Google -->
+            <dependency>
+                <groupId>com.google.gwt.google-apis</groupId>
+                <artifactId>gwt-ajaxloader</artifactId>
+                <version>1.1.0</version>
+                <scope>compile</scope>
+            </dependency>
+
+            <!-- GWT -->
+            <dependency>
+                <groupId>com.google.gwt</groupId>
+                <artifactId>gwt-user</artifactId>
+                <version>${gwt.version}</version>
+                <scope>provided</scope> <!-- don't copy to jar -->
+            </dependency>
             <!-- GWT needed for mvn integration-test -->
-			<dependency>
-				<groupId>com.google.gwt</groupId>
-				<artifactId>gwt-dev</artifactId>
-				<version>${gwt.version}</version>
-				<scope>test</scope> <!-- don't copy to jar -->
-			</dependency>
-            
-			<!-- Testing -->
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>4.8.1</version>
-				<scope>test</scope> <!-- don't copy to jar -->
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+            <dependency>
+                <groupId>com.google.gwt</groupId>
+                <artifactId>gwt-dev</artifactId>
+                <version>${gwt.version}</version>
+                <scope>test</scope> <!-- don't copy to jar -->
+            </dependency>
+
+            <!-- Testing -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.8.1</version>
+                <scope>test</scope> <!-- don't copy to jar -->
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <!-- Run by using: mvn clean integration-test deploy -->
     <!-- https://issues.sonatype.org/browse/OSSRH-4661 -->
-    <!-- Build a local maven repo: mvn -DaltDeploymentRepository=snapshot-repo::default::file:./distribution/snapshots clean deploy -->
+    <!-- Build a local maven repo: mvn -DaltDeploymentRepository=snapshot-repo::default::file:./distribution/snapshots 
+        clean deploy -->
     <distributionManagement>
         <repository>
             <id>sona-nexus-deploy</id> <!-- Add to settings.xml <server><id>sona-nexus-deploy</id> -->
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
         </repository>
         <snapshotRepository>
-            <id>sona-nexus-deploy</id> 
+            <id>sona-nexus-deploy</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
-    </distributionManagement> 
+    </distributionManagement>
 </project>


### PR DESCRIPTION
1. I formatted the pom tabs to spaces, b/c its formats odd on github. 
2. I added back what was removed. 
3. I changed the teamcity server. While I think codebetter is good, its not easy to configure local dev and remote deployment setups. I've got an open source license and setup a teamcity server for arcbees which we build gwtp on it too. I don't mind have more than one. It auto deploys to snapshot, if tests pass and deploys the showcase. 

'mvn integration-test' tests the gwt test suite, which runs far faster than running each test individually. So there isn't a need for parallel processing for this duty. 

http://mojo.codehaus.org/gwt-maven-plugin/user-guide/testing.html - more notes on 'mvn integration-test',  Also this allows for using something like jukito to be used for mocking with junit testing, but the librtrary really doesn't need that type of testing at this time, well my feeling anyway. 

This is open for discussion if you like, I'm always willing to change course if it doesn't improve it. Feel free to try it out. 
