### PR TITLE
Fixed typo In Polyline JavaDoc

### DIFF
--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/overlays/PolylineOptions.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/overlays/PolylineOptions.java
@@ -30,7 +30,7 @@ import com.google.gwt.maps.client.mvc.MVCArray;
 /**
  * polyline options <br>
  * <br>
- * See <a href= "https://developers.google.com/maps/documentation/javascript/reference#PolygonOptions" >PolygonOptions
+ * See <a href= "https://developers.google.com/maps/documentation/javascript/reference#PolylineOptions" >PolygonOptions
  * API Doc</a>
  */
 public class PolylineOptions extends JavaScriptObject {


### PR DESCRIPTION
Fixed JavaDoc typo from Issue #164
