### PR TITLE
Add NOT_FOUND to PlaceServiceStatus

### DIFF
--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/placeslib/PlacesServiceStatus.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/placeslib/PlacesServiceStatus.java
@@ -50,7 +50,12 @@ public enum PlacesServiceStatus {
   /**
    * No result was found for this request.
    */
-  ZERO_RESULTS;
+  ZERO_RESULTS,
+
+  /**
+   * Undocumented in API but is returned by service in some cases.
+   */
+  NOT_FOUND;
 
   public String value() {
     return name().toLowerCase();


### PR DESCRIPTION
Although this status is not documented it is returned by service in some cases. This causes exception when enum constant is parsed in com.google.gwt.maps.client.placeslib.PlacesServiceStatus#fromValue.

Request example

URL

``` bash
https://maps.googleapis.com/maps/api/js/PlaceService.GetPlaceDetails?1sCkQyAAAADDrVJSnZJy90R-zu23yOP6nAf7wmpaws0Hmm8_yI9m3TlcJ6df6-7T1ZpZN91Wrusk4Hz50ZHXIyA1Ube81qKhIQFD9dg2uod4VN5kP6TKWwExoU4IbBEMnbinzwFd1hIHHMgmNB0uM&2ssv&callback=_xdc_._guqcne&token=56049
```

Response

``` json
_xdc_._guqcne && _xdc_._guqcne( {
   "html_attributions" : [],
   "status" : "NOT_FOUND"
})`
```
