### PR TITLE
Fix entry wrapper functions

### DIFF
--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/events/MapHandlerRegistration.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/events/MapHandlerRegistration.java
@@ -111,9 +111,9 @@ public class MapHandlerRegistration {
   // is ugly, but is a cyclic generic type, so suppressed
   private static native <E extends MapEvent> JavaScriptObject addHandlerImpl(JavaScriptObject jso, String eventName,
       MapHandler<E> handler, MapEventFormatter<E> formatter) /*-{
-    var callback = function(event) {
-      $entry(@com.google.gwt.maps.client.events.MapHandlerRegistration::onCallback(Lcom/google/gwt/maps/client/events/MapHandler;Lcom/google/gwt/ajaxloader/client/Properties;Lcom/google/gwt/maps/client/events/MapEventFormatter;)(handler, event, formatter));
-    };
+    var callback = $entry(function(event) {
+      @com.google.gwt.maps.client.events.MapHandlerRegistration::onCallback(Lcom/google/gwt/maps/client/events/MapHandler;Lcom/google/gwt/ajaxloader/client/Properties;Lcom/google/gwt/maps/client/events/MapEventFormatter;)(handler, event, formatter);
+    });
     return $wnd.google.maps.event.addListener(jso, eventName, callback)
   }-*/;
 
@@ -129,12 +129,12 @@ public class MapHandlerRegistration {
   // is ugly, but is a cyclic generic type, so suppressed
   private static native <E extends MapEvent> JavaScriptObject addHandlerImplMvc(JavaScriptObject jso, String eventName,
       MapHandler<E> handler, MapEventFormatter<E> formatter) /*-{
-    var callback = function(event) {
+    var callback = $entry(function(event) {
       var eventCon = {
         index : event
       };
-      $entry(@com.google.gwt.maps.client.events.MapHandlerRegistration::onCallback(Lcom/google/gwt/maps/client/events/MapHandler;Lcom/google/gwt/ajaxloader/client/Properties;Lcom/google/gwt/maps/client/events/MapEventFormatter;)(handler, eventCon, formatter));
-    };
+      @com.google.gwt.maps.client.events.MapHandlerRegistration::onCallback(Lcom/google/gwt/maps/client/events/MapHandler;Lcom/google/gwt/ajaxloader/client/Properties;Lcom/google/gwt/maps/client/events/MapEventFormatter;)(handler, eventCon, formatter);
+    });
     return $wnd.google.maps.event.addListener(jso, eventName, callback)
   }-*/;
 
@@ -150,12 +150,12 @@ public class MapHandlerRegistration {
   // is ugly, but is a cyclic generic type, so suppressed
   private static native <E extends MapEvent> JavaScriptObject addHandlerImplDrawing(JavaScriptObject jso,
       String eventName, MapHandler<E> handler, MapEventFormatter<E> formatter) /*-{
-    var callback = function(event) {
+    var callback = $entry(function(event) {
       var eventCon = {
         overlay : event
       };
-      $entry(@com.google.gwt.maps.client.events.MapHandlerRegistration::onCallback(Lcom/google/gwt/maps/client/events/MapHandler;Lcom/google/gwt/ajaxloader/client/Properties;Lcom/google/gwt/maps/client/events/MapEventFormatter;)(handler, eventCon, formatter));
-    };
+      @com.google.gwt.maps.client.events.MapHandlerRegistration::onCallback(Lcom/google/gwt/maps/client/events/MapHandler;Lcom/google/gwt/ajaxloader/client/Properties;Lcom/google/gwt/maps/client/events/MapEventFormatter;)(handler, eventCon, formatter);
+    });
     return $wnd.google.maps.event.addListener(jso, eventName, callback)
   }-*/;
 
@@ -253,9 +253,9 @@ public class MapHandlerRegistration {
 
   private static native <E> void addDomListener(JavaScriptObject object, String eventName, MapHandler<?> handler,
       boolean capture) /*-{
-    var callback = function(event) {
+    var callback = $entry(function(event) {
       @com.google.gwt.maps.client.events.MapHandlerRegistration::addDomListenerImpl(Lcom/google/gwt/ajaxloader/client/Properties;Lcom/google/gwt/maps/client/events/MapHandler;)(event, handler)
-    };
+    });
     $wnd.google.maps.event.addDomListener(object, eventName, callback, capture);
   }-*/;
 

--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/maptypes/ImageMapTypeOptions.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/maptypes/ImageMapTypeOptions.java
@@ -68,9 +68,9 @@ public class ImageMapTypeOptions extends JavaScriptObject {
    * @param callback
    */
   public final native void setTileUrl(TileUrlCallBack callback) /*-{
-    this.getTileUrl = function(point, zoomLevel) {
+    this.getTileUrl = $entry(function(point, zoomLevel) {
       return @com.google.gwt.maps.client.maptypes.ImageMapTypeOptions::processTileUrlCallBack(Lcom/google/gwt/maps/client/base/Point;ILcom/google/gwt/maps/client/maptypes/TileUrlCallBack;)(point, zoomLevel, callback);
-    };
+    });
   }-*/;
 
   /**

--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/mvc/MVCArray.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/mvc/MVCArray.java
@@ -109,9 +109,9 @@ public class MVCArray<T extends JavaScriptObject> extends MVCObject<T> {
    * @param callback
    */
   private final native void onCallback(MVCArrayCallback<T> callback) /*-{
-    var cb = function(element, index) {
-      $entry(@com.google.gwt.maps.client.mvc.MVCArray::forEachImplCallback(Lcom/google/gwt/core/client/JavaScriptObject;ILcom/google/gwt/maps/client/mvc/MVCArrayCallback;)(element, index, callback));
-    };
+    var cb = $entry(function(element, index) {
+      @com.google.gwt.maps.client.mvc.MVCArray::forEachImplCallback(Lcom/google/gwt/core/client/JavaScriptObject;ILcom/google/gwt/maps/client/mvc/MVCArrayCallback;)(element, index, callback);
+    });
     this.forEach(cb);
   }-*/;
 

--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/overlays/OverlayView.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/overlays/OverlayView.java
@@ -83,17 +83,17 @@ public class OverlayView extends MVCObject<OverlayView> {
 
     MapOverlay.prototype = new $wnd.google.maps.OverlayView();
 
-    MapOverlay.prototype.onAdd = function() {
-      $entry(@com.google.gwt.maps.client.overlays.OverlayView::onAddCallback(Lcom/google/gwt/maps/client/overlays/overlayhandlers/OverlayViewOnAddHandler;Lcom/google/gwt/maps/client/overlays/overlayhandlers/OverlayViewMethods;)(onAddHandler, this));
-    };
+    MapOverlay.prototype.onAdd = $entry(function() {
+      @com.google.gwt.maps.client.overlays.OverlayView::onAddCallback(Lcom/google/gwt/maps/client/overlays/overlayhandlers/OverlayViewOnAddHandler;Lcom/google/gwt/maps/client/overlays/overlayhandlers/OverlayViewMethods;)(onAddHandler, this);
+    });
 
-    MapOverlay.prototype.onRemove = function() {
-      $entry(@com.google.gwt.maps.client.overlays.OverlayView::onRemoveCallback(Lcom/google/gwt/maps/client/overlays/overlayhandlers/OverlayViewOnRemoveHandler;Lcom/google/gwt/maps/client/overlays/overlayhandlers/OverlayViewMethods;)(onRemoveHandler, this));
-    };
+    MapOverlay.prototype.onRemove = $entry(function() {
+        @com.google.gwt.maps.client.overlays.OverlayView::onRemoveCallback(Lcom/google/gwt/maps/client/overlays/overlayhandlers/OverlayViewOnRemoveHandler;Lcom/google/gwt/maps/client/overlays/overlayhandlers/OverlayViewMethods;)(onRemoveHandler, this);
+    });
 
-    MapOverlay.prototype.draw = function() {
-      $entry(@com.google.gwt.maps.client.overlays.OverlayView::onDrawCallback(Lcom/google/gwt/maps/client/overlays/overlayhandlers/OverlayViewOnDrawHandler;Lcom/google/gwt/maps/client/overlays/overlayhandlers/OverlayViewMethods;)(onDrawHandler, this));
-    };
+    MapOverlay.prototype.draw = $enyry(function() {
+      @com.google.gwt.maps.client.overlays.OverlayView::onDrawCallback(Lcom/google/gwt/maps/client/overlays/overlayhandlers/OverlayViewOnDrawHandler;Lcom/google/gwt/maps/client/overlays/overlayhandlers/OverlayViewMethods;)(onDrawHandler, this);
+    });
 
     var jso = new MapOverlay(map);
     return jso;

--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/placeslib/AutocompleteService.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/placeslib/AutocompleteService.java
@@ -50,9 +50,9 @@ public class AutocompleteService extends JavaScriptObject {
   }-*/;
 
   public final native void getPlacePredictions(AutocompletionRequest request, PlacePredictionsHandler handler) /*-{
-    var callback = function (results, status) {
-      $entry(@com.google.gwt.maps.client.placeslib.AutocompleteService::processPlacePredictions(Lcom/google/gwt/core/client/JsArray;Ljava/lang/String;Lcom/google/gwt/maps/client/placeslib/PlacePredictionsHandler;)(results, status, handler));
-    };
+    var callback = $entry(function (results, status) {
+      @com.google.gwt.maps.client.placeslib.AutocompleteService::processPlacePredictions(Lcom/google/gwt/core/client/JsArray;Ljava/lang/String;Lcom/google/gwt/maps/client/placeslib/PlacePredictionsHandler;)(results, status, handler);
+    });
     this.getPlacePredictions(request, callback);
   }-*/;
 

--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/placeslib/PlacesService.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/placeslib/PlacesService.java
@@ -74,9 +74,9 @@ public class PlacesService extends JavaScriptObject {
    * @param handler
    */
   public final native void getDetails(PlaceDetailsRequest request, PlaceDetailsHandler handler) /*-{
-    var callback = function(result, status) {
-      $entry(@com.google.gwt.maps.client.placeslib.PlacesService::processDetailsCallback(Lcom/google/gwt/maps/client/placeslib/PlaceResult;Ljava/lang/String;Lcom/google/gwt/maps/client/placeslib/PlaceDetailsHandler;)(result, status, handler));
-    };
+    var callback = $entry(function(result, status) {
+      @com.google.gwt.maps.client.placeslib.PlacesService::processDetailsCallback(Lcom/google/gwt/maps/client/placeslib/PlaceResult;Ljava/lang/String;Lcom/google/gwt/maps/client/placeslib/PlaceDetailsHandler;)(result, status, handler);
+    });
     this.getDetails(request, callback);
   }-*/;
 
@@ -95,9 +95,9 @@ public class PlacesService extends JavaScriptObject {
    * @param handler
    */
   public final native void nearbySearch(PlaceSearchRequest request, PlaceSearchHandler handler) /*-{
-    var callback = function(results, status, pagination) {
-      $entry(@com.google.gwt.maps.client.placeslib.PlacesService::processSearchCallback(Lcom/google/gwt/core/client/JsArray;Ljava/lang/String;Lcom/google/gwt/maps/client/placeslib/PlaceSearchPagination;Lcom/google/gwt/maps/client/placeslib/PlaceSearchHandler;)(results, status, pagination, handler));
-    };
+    var callback = $entry(function(results, status, pagination) {
+      @com.google.gwt.maps.client.placeslib.PlacesService::processSearchCallback(Lcom/google/gwt/core/client/JsArray;Ljava/lang/String;Lcom/google/gwt/maps/client/placeslib/PlaceSearchPagination;Lcom/google/gwt/maps/client/placeslib/PlaceSearchHandler;)(results, status, pagination, handler);
+    });
     this.nearbySearch(request, callback);
   }-*/;
 
@@ -113,9 +113,9 @@ public class PlacesService extends JavaScriptObject {
    * it.
    */
   public final native void textSearch(TextSearchRequest request, PlaceTextSearchHandler handler) /*-{
-    var callback = function(results, status) {
-      $entry(@com.google.gwt.maps.client.placeslib.PlacesService::processTextSearch(Lcom/google/gwt/core/client/JsArray;Ljava/lang/String;Lcom/google/gwt/maps/client/placeslib/PlaceTextSearchHandler;)(results, status, handler));
-    };
+    var callback = $entry(function(results, status) {
+      @com.google.gwt.maps.client.placeslib.PlacesService::processTextSearch(Lcom/google/gwt/core/client/JsArray;Ljava/lang/String;Lcom/google/gwt/maps/client/placeslib/PlaceTextSearchHandler;)(results, status, handler);
+    });
     this.textSearch(request, callback);
   }-*/;
 

--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/services/DirectionsService.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/services/DirectionsService.java
@@ -58,9 +58,9 @@ public class DirectionsService extends JavaScriptObject {
    * @param handler
    */
   public final native void route(DirectionsRequest request, DirectionsResultHandler handler) /*-{
-    var callback = function(result, status) {
-      $entry(@com.google.gwt.maps.client.services.DirectionsService::routeImpl(Lcom/google/gwt/maps/client/services/DirectionsResult;Ljava/lang/String;Lcom/google/gwt/maps/client/services/DirectionsResultHandler;)(result, status, handler));
-    };
+    var callback = $entry(function(result, status) {
+      @com.google.gwt.maps.client.services.DirectionsService::routeImpl(Lcom/google/gwt/maps/client/services/DirectionsResult;Ljava/lang/String;Lcom/google/gwt/maps/client/services/DirectionsResultHandler;)(result, status, handler);
+    });
 
     this.route(request, callback);
   }-*/;

--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/services/DistanceMatrixService.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/services/DistanceMatrixService.java
@@ -51,9 +51,9 @@ public class DistanceMatrixService extends JavaScriptObject {
   }-*/;
 
   public final native void getDistanceMatrix(DistanceMatrixRequest request, DistanceMatrixRequestHandler handler) /*-{
-    var callback = function(response, status) {
-      $entry(@com.google.gwt.maps.client.services.DistanceMatrixService::getDistanceMatrixImpl(Lcom/google/gwt/maps/client/services/DistanceMatrixResponse;Ljava/lang/String;Lcom/google/gwt/maps/client/services/DistanceMatrixRequestHandler;)(response, status, handler));
-    };
+    var callback = $entry(function(response, status) {
+      @com.google.gwt.maps.client.services.DistanceMatrixService::getDistanceMatrixImpl(Lcom/google/gwt/maps/client/services/DistanceMatrixResponse;Ljava/lang/String;Lcom/google/gwt/maps/client/services/DistanceMatrixRequestHandler;)(response, status, handler);
+    });
     this.getDistanceMatrix(request, callback);
   }-*/;
 

--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/services/ElevationService.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/services/ElevationService.java
@@ -59,9 +59,9 @@ public class ElevationService extends JavaScriptObject {
    * @param handler
    */
   public final native void getElevationAlongPath(PathElevationRequest request, ElevationServiceHandler handler) /*-{
-    var callback = function(result, status) {
-      $entry(@com.google.gwt.maps.client.services.ElevationService::processHandler(Lcom/google/gwt/core/client/JsArray;Ljava/lang/String;Lcom/google/gwt/maps/client/services/ElevationServiceHandler;)(result, status, handler));
-    };
+    var callback = $entry(function(result, status) {
+      @com.google.gwt.maps.client.services.ElevationService::processHandler(Lcom/google/gwt/core/client/JsArray;Ljava/lang/String;Lcom/google/gwt/maps/client/services/ElevationServiceHandler;)(result, status, handler);
+    });
     this.getElevationAlongPath(request, callback);
   }-*/;
 
@@ -72,9 +72,9 @@ public class ElevationService extends JavaScriptObject {
    * @param handler
    */
   public final native void getElevationForLocations(LocationElevationRequest request, ElevationServiceHandler handler) /*-{
-    var callback = function(result, status) {
-      $entry(@com.google.gwt.maps.client.services.ElevationService::processHandler(Lcom/google/gwt/core/client/JsArray;Ljava/lang/String;Lcom/google/gwt/maps/client/services/ElevationServiceHandler;)(result, status, handler));
-    };
+    var callback = $entry(function(result, status) {
+      @com.google.gwt.maps.client.services.ElevationService::processHandler(Lcom/google/gwt/core/client/JsArray;Ljava/lang/String;Lcom/google/gwt/maps/client/services/ElevationServiceHandler;)(result, status, handler);
+    });
     this.getElevationForLocations(request, callback);
   }-*/;
 

--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/services/Geocoder.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/services/Geocoder.java
@@ -52,9 +52,9 @@ public class Geocoder extends JavaScriptObject {
    * @param handler
    */
   public final native void geocode(GeocoderRequest request, GeocoderRequestHandler handler) /*-{
-    var callback = function(results, status) {
-      $entry(@com.google.gwt.maps.client.services.Geocoder::geocodeImpl(Lcom/google/gwt/core/client/JsArray;Ljava/lang/String;Lcom/google/gwt/maps/client/services/GeocoderRequestHandler;)(results, status, handler));
-    };
+    var callback = $entry(function(results, status) {
+      @com.google.gwt.maps.client.services.Geocoder::geocodeImpl(Lcom/google/gwt/core/client/JsArray;Ljava/lang/String;Lcom/google/gwt/maps/client/services/GeocoderRequestHandler;)(results, status, handler);
+    });
     this.geocode(request, callback);
   }-*/;
 

--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/services/MaxZoomService.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/services/MaxZoomService.java
@@ -57,9 +57,9 @@ public class MaxZoomService extends JavaScriptObject {
    * @param handler
    */
   public final native void getMaxZoomAtLatLng(LatLng latlng, MaxZoomServiceHandler handler) /*-{
-    var callback = function(result) {
-      $entry(@com.google.gwt.maps.client.services.MaxZoomService::getMaxZoomAtLatLngImpl(Lcom/google/gwt/maps/client/services/MaxZoomResult;Lcom/google/gwt/maps/client/services/MaxZoomServiceHandler;)(result, handler));
-    };
+    var callback = $entry(function(result) {
+      @com.google.gwt.maps.client.services.MaxZoomService::getMaxZoomAtLatLngImpl(Lcom/google/gwt/maps/client/services/MaxZoomResult;Lcom/google/gwt/maps/client/services/MaxZoomServiceHandler;)(result, handler);
+    });
     this.getMaxZoomAtLatLng(latlng, callback);
   }-*/;
 

--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/streetview/StreetViewPanoramaImpl.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/streetview/StreetViewPanoramaImpl.java
@@ -125,9 +125,9 @@ public class StreetViewPanoramaImpl extends MVCObject<StreetViewPanoramaImpl> {
    * @param provider
    */
   public final native void registerPanoProvider(StreetViewPanoramaProvider provider) /*-{
-    this.panoProvider = function(pano, zoom, tileX, tileY) {
+    this.panoProvider = $entry(function(pano, zoom, tileX, tileY) {
       provider.@com.google.gwt.maps.client.streetview.StreetViewPanoramaProvider::getPanoData(Ljava/lang/String;III)(pano, zoom, tileX, tileY);
-    }
+    });
   }-*/;
 
   /**

--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/streetview/StreetViewPanoramaOptions.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/streetview/StreetViewPanoramaOptions.java
@@ -235,12 +235,12 @@ public class StreetViewPanoramaOptions extends JavaScriptObject {
    * @param provider
    */
   public final native void setPanoProvider(StreetViewPanoramaProvider provider) /*-{
-    this.panoProvider = function(pano, zoom, tileX, tileY) {
+    this.panoProvider = $entry(function(pano, zoom, tileX, tileY) {
       var z = zoom ? zoom : -1;
       var x = tileX ? tileX : -1;
       var y = tileY ? tileY : -1;
       return @com.google.gwt.maps.client.streetview.StreetViewPanoramaOptions::setPanoProviderImpl(Ljava/lang/String;IIILcom/google/gwt/maps/client/streetview/StreetViewPanoramaProvider;)(pano, z, x, y, provider);
-    }
+    });
   }-*/;
 
   private static StreetViewPanoramaData setPanoProviderImpl(String pano, int zoom, int tileX, int tileY,

--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/streetview/StreetViewService.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/streetview/StreetViewService.java
@@ -68,9 +68,9 @@ public class StreetViewService extends JavaScriptObject {
    */
   public final native void getPanoramaById(String pano, PanoramaIdHandler handler) /*-{
     // 
-    var callback = function(data, status) {
-      $entry(@com.google.gwt.maps.client.streetview.StreetViewService::getPanoramaByIdImpl(Lcom/google/gwt/maps/client/streetview/StreetViewPanoramaData;Ljava/lang/String;Lcom/google/gwt/maps/client/streetview/PanoramaIdHandler;)(data, status, handler));
-    };
+    var callback = $entry(function(data, status) {
+      @com.google.gwt.maps.client.streetview.StreetViewService::getPanoramaByIdImpl(Lcom/google/gwt/maps/client/streetview/StreetViewPanoramaData;Ljava/lang/String;Lcom/google/gwt/maps/client/streetview/PanoramaIdHandler;)(data, status, handler);
+    });
     this.getPanoramaById(pano, callback);
   }-*/;
 
@@ -88,9 +88,9 @@ public class StreetViewService extends JavaScriptObject {
    * @param handler
    */
   public final native void getPanoramaByLocation(LatLng latlng, double radius, PanoramaByLocationHandler handler) /*-{
-    var callback = function(data, status) {
-      $entry(@com.google.gwt.maps.client.streetview.StreetViewService::getPanoramaByLocationImpl(Lcom/google/gwt/maps/client/streetview/StreetViewPanoramaData;Ljava/lang/String;Lcom/google/gwt/maps/client/streetview/PanoramaByLocationHandler;)(data, status, handler));
-    };
+    var callback = $entry(function(data, status) {
+      @com.google.gwt.maps.client.streetview.StreetViewService::getPanoramaByLocationImpl(Lcom/google/gwt/maps/client/streetview/StreetViewPanoramaData;Ljava/lang/String;Lcom/google/gwt/maps/client/streetview/PanoramaByLocationHandler;)(data, status, handler);
+    });
     this.getPanoramaByLocation(latlng, radius, callback);
   }-*/;
 

--- a/gwt-maps-api/src/main/java/com/google/gwt/maps/client/streetview/StreetViewTileData.java
+++ b/gwt-maps-api/src/main/java/com/google/gwt/maps/client/streetview/StreetViewTileData.java
@@ -55,9 +55,9 @@ public class StreetViewTileData extends JavaScriptObject {
    * @param handler
    */
   public final native String getTileUrl(String pano, int zoom, int tileX, int tileY, TileUrlHandler handler) /*-{
-    this.getTileUrl = function(pano, zoom, tileX, tileY) {
+    this.getTileUrl = $entry(function(pano, zoom, tileX, tileY) {
       return @com.google.gwt.maps.client.streetview.StreetViewTileData::getTileUrlImpl(Ljava/lang/String;IIILcom/google/gwt/maps/client/streetview/TileUrlHandler;)(pano, zoom, tileX, tileY, handler);
-    };
+    });
   }-*/;
 
   private final static String getTileUrlImpl(String pano, int zoom, int tileX, int tileY, TileUrlHandler handler) {

--- a/gwt-maps-utility/markerclustererplus/src/main/java/com/google/gwt/maps/utility/markerclustererplus/client/MarkerClustererOptions.java
+++ b/gwt-maps-utility/markerclustererplus/src/main/java/com/google/gwt/maps/utility/markerclustererplus/client/MarkerClustererOptions.java
@@ -54,10 +54,10 @@ public class MarkerClustererOptions extends JavaScriptObject {
   }
 
   private native JavaScriptObject getCalculatorFunction(final ClusterCalculator calculator) /*-{
-      var fn = function (markers, nStyles) {
+      var fn = $entry(function (markers, nStyles) {
           var info = calculator.@com.google.gwt.maps.utility.markerclustererplus.client.ClusterCalculator::execute(Lcom/google/gwt/core/client/JsArray;I)(markers, nStyles);
           return info;
-      };
+      });
       return fn;
   }-*/;
 


### PR DESCRIPTION
`$entry()` function should wrap around the whole JavaScript function as in the example in [GWT Documentation](http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsJSNI.html#sharing).

A missing `$entry()` wrapper can block RPC calls heading to the server.

This caused the UI to be semi-responsive in the Vaadin wrapper of this library, the [GoogleMaps Add-on](https://vaadin.com/directory#!addon/googlemaps-add-on).